### PR TITLE
[Pure] and [IsPure] means the same 

### DIFF
--- a/PurityAnalyzer.Tests/PureAttribute/PureIsSameAsIsPure.cs
+++ b/PurityAnalyzer.Tests/PureAttribute/PureIsSameAsIsPure.cs
@@ -1,0 +1,97 @@
+﻿using FluentAssertions;
+using NUnit.Framework;
+
+namespace PurityAnalyzer.Tests.PureAttribute
+{
+    [TestFixture]
+    public class PureIsSameAsIsPure
+    {
+        [Test]
+        public void CaseWhereMembersArePure()
+        {
+            string code = @"
+using System;
+
+public class PureAttribute : Attribute
+{
+}
+
+[Pure]
+public class Class1
+{
+
+    public int Prop1
+    {
+        get
+        {
+            return 1;
+        }
+    }
+
+    public int DoSomething(int a)
+    {
+        return a + 1;
+    }
+}";
+
+            var dignostics = Utilities.RunPurityAnalyzer(code);
+            dignostics.Length.Should().Be(0);
+        }
+
+        [Test]
+        public void PureOnClassRequiresInstanceConstructorToBePure()
+        {
+            string code = @"
+using System;
+
+public class PureAttribute : Attribute
+{
+}
+
+[Pure]
+public class Class1
+{
+    public Class1() => AnotherClass.state = 1;
+}
+
+public static class AnotherClass
+{
+    public static int state;
+}
+";
+
+            var dignostics = Utilities.RunPurityAnalyzer(code);
+            dignostics.Length.Should().BePositive();
+
+        }
+
+        [Test]
+        public void PureAttributeOnClassRequiresInstanceConstructorToBePure()
+        {
+            string code = @"
+using System;
+
+public class PureAttribute : Attribute
+{
+}
+
+[PureAttribute]
+public class Class1
+{
+    public Class1() => AnotherClass.state = 1;
+}
+
+public static class AnotherClass
+{
+    public static int state;
+}
+";
+
+            var dignostics = Utilities.RunPurityAnalyzer(code);
+            dignostics.Length.Should().BePositive();
+
+        }
+    }
+
+
+}

--- a/PurityAnalyzer.Tests/PurityAnalyzer.Tests.csproj
+++ b/PurityAnalyzer.Tests/PurityAnalyzer.Tests.csproj
@@ -226,6 +226,7 @@
     <Compile Include="NotUsedAsObjectAttributeTests\DotNetMethodsTests.cs" />
     <Compile Include="NotUsedAsObjectAttributeTests\TypeParametersOnClassLevelTests.cs" />
     <Compile Include="NotUsedAsObjectAttributeTests\Tests.cs" />
+    <Compile Include="PureAttribute\PureIsSameAsIsPure.cs" />
     <Compile Include="PureLambdaTests\Tests.cs" />
     <Compile Include="ReturnsNewObjectAttribute\DotNetFrameworkTests.cs" />
     <Compile Include="ReturnsNewObjectAttribute\ReturnsNewObjectAttributeTests.cs" />

--- a/PurityAnalyzer/Utils.cs
+++ b/PurityAnalyzer/Utils.cs
@@ -39,7 +39,8 @@ namespace PurityAnalyzer
 
         public static bool IsIsPureAttribute(string attributeName)
         {
-            return attributeName == "IsPure" || attributeName == "IsPure" + "Attribute";
+            return attributeName == "IsPure" || attributeName == "IsPure" + "Attribute"
+                || attributeName == "Pure"   || attributeName == "Pure"   + "Attribute";
         }
 
         public static bool IsIsPureExceptLocallyAttribute(string attributeName)


### PR DESCRIPTION
I've made changes to support and treat [Pure] exactly the same as [IsPure].

Why?

1) .NET Framework already have  System.Diagnostics.Contracts.PureAttribute
2) Resharper doesn't recognize [IsPure], It's working only with [Pure] attribute (https://www.jetbrains.com/help/resharper/Reference__Code_Annotation_Attributes.html#PureAttribute)